### PR TITLE
fix(eslint-config): Fix the repository url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-I appreciate your considering contributing `eslint-config-moneyforward`. This document is a guide to help make your contribution easier.
+I appreciate your considering contributing `frontend-tools`. This document is a guide to help make your contribution easier.
 
 ## Getting Started
 
@@ -34,12 +34,12 @@ The main scripts used during development are:
 
 ### Reporting Issues
 
-1. Check [the Issue Tracker](https://github.com/moneyforward/eslint-config-moneyforward/issues) for existing issues.
-2. When requesting a new issue or feature, please use [the templates](https://github.com/moneyforward/eslint-config-moneyforward/issues/new/choose) and provide as much detail as possible.
+1. Check [the Issue Tracker](https://github.com/moneyforward/frontend-tools/issues) for existing issues.
+2. When requesting a new issue or feature, please use [the templates](https://github.com/moneyforward/frontend-tools/issues/new/choose) and provide as much detail as possible.
 
 ### Development
 
-1. Check [the Issue Tracker](https://github.com/moneyforward/eslint-config-moneyforward/issues), make sure if there is anything relevant to the problem you are trying to solve.
+1. Check [the Issue Tracker](https://github.com/moneyforward/frontend-tools/issues), make sure if there is anything relevant to the problem you are trying to solve.
 2. Keep the repository you did fork up to date.
 
    ```bash
@@ -79,7 +79,9 @@ The main scripts used during development are:
 
 ### Code Style
 
-- Code according to [ESlint](/.eslintrc.js) and [Prettier](/.prettierrc.js) rules.
+- Code according to[Prettier](/prettier.config.js) and the following ESLint rules:
+  - **eslint-config-moneyforward**: [eslint.config.mjs](/packages/eslint-config/eslint.config.mjs)
+  - **@moneyforward/stylelint-config**: [stylelint.config.js](/packages/stylelint-config/eslint.config.js)
 - Keep your code in a consistent style.
 
 ### Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 
 ## Pre-flight checklist
 
-- [ ] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
+- [ ] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
 - [ ] Performed a self-review of my code
 
 ## References

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Money Forward, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,7 +1,7 @@
 # eslint-config-moneyforward
 
 [![Version](https://img.shields.io/npm/v/eslint-config-moneyforward.svg?style=flat-square)](https://www.npmjs.com/package/eslint-config-moneyforward?activeTab=versions)
-[![License](https://img.shields.io/github/license/moneyforward/eslint-config-moneyforward.svg?style=flat-square)](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/moneyforward/frontend-tools.svg?style=flat-square)](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config/LICENSE)
 
 This package provides moneyforward's `.eslintrc` as an extensible shared config.
 
@@ -180,8 +180,8 @@ npm uninstall eslint-plugin-promise eslint-plugin-import eslint-plugin-unicorn \
 
 ## Troubleshooting
 
-- [ESLint Configuration Issue with Non-Standard TSConfig Filenames in Flat Config](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config-moneyforward/docs/troubleshooting/eslint-configuration-issue-with-non-standard-tsconfig-filenames-in-flat-config.md)
+- [ESLint Configuration Issue with Non-Standard TSConfig Filenames in Flat Config](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config/docs/troubleshooting/eslint-configuration-issue-with-non-standard-tsconfig-filenames-in-flat-config.md)
 
 ## License
 
-Open source [licensed as MIT](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config-moneyforward/LICENSE).
+Open source [licensed as MIT](https://github.com/moneyforward/frontend-tools/blob/main/packages/eslint-config/LICENSE).

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -46,7 +46,7 @@
   "bugs": {
     "url": "https://github.com/moneyforward/frontend-tools/issues"
   },
-  "homepage": "https://github.com/moneyforward/frontend-tools/tree/main/packages/eslint-config-moneyforward#readme",
+  "homepage": "https://github.com/moneyforward/frontend-tools/tree/main/packages/eslint-config#readme",
   "dependencies": {
     "@next/eslint-plugin-next": "^15.0.3",
     "@typescript-eslint/eslint-plugin": "^8.16.0",


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

Due to the repository name change and the move of `eslint-config-moneyforward` to a workspace under the monorepo, all hard-coded URLs must be revised.

There are no changes to the `eslint-config-moneyforward` codebase, but [the URL listed in the npm registry](https://www.npmjs.com/package/eslint-config-moneyforward) needs to be updated, so this fix will be released as a patch update.

<img width="438" alt="スクリーンショット 2025-02-10 15 02 30" src="https://github.com/user-attachments/assets/aad6b7a8-fd24-4c4b-8986-4b3074c3f08b" />


## Linked PR / Issues

<!-- Fixes # (issue) -->

- #363

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/eslint-config-moneyforward/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->
