### PR TITLE
fix(frontend): accept using `@deprecated` tag in JSDoc

### DIFF
--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -22,6 +22,10 @@ module.exports = {
     // https://typescript-eslint.io/rules/dot-notation/
     '@typescript-eslint/dot-notation': baseBestPracticesRules['dot-notation'],
 
+    // Use of `@deprecated` tag should be acceptable during code migration.
+    // https://typescript-eslint.io/rules/no-deprecated/
+    '@typescript-eslint/no-deprecated': ['warn'],
+
     // Disallow unused expressions.
     // https://typescript-eslint.io/rules/no-unused-expressions/
     // Replace 'no-unused-expressions' rule with '@typescript-eslint' version

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/next/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/next/__snapshots__/snapshot.test.js.snap
@@ -158,7 +158,7 @@ exports[`should match ESLint configuration snapshot: next 1`] = `
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/react/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/react/__snapshots__/snapshot.test.js.snap
@@ -95,7 +95,7 @@ exports[`should match ESLint configuration snapshot: react 1`] = `
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/eslintrc/storybook/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/eslintrc/storybook/__snapshots__/snapshot.test.js.snap
@@ -95,7 +95,7 @@ exports[`should match ESLint configuration snapshot: storybook 1`] = `
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/next/__snapshots__/snapshot.test.js.snap
@@ -241,7 +241,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,
@@ -560,7 +560,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       {
         "enforceForClassFields": true,
         "exceptMethods": [],
-        "ignoreOverrideMethods": false,
       },
     ],
     "complexity": [
@@ -629,7 +628,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       "expression",
       {
         "allowArrowFunctions": false,
-        "allowTypeAnnotation": false,
         "overrides": {},
       },
     ],
@@ -2150,16 +2148,11 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
         "allow": [],
         "builtinGlobals": false,
         "hoist": "functions",
-        "ignoreFunctionTypeParameterNameValueShadow": true,
         "ignoreOnInitialization": false,
-        "ignoreTypeValueShadow": true,
       },
     ],
     "no-shadow-restricted-names": [
       2,
-      {
-        "reportGlobalThis": false,
-      },
     ],
     "no-sparse-arrays": [
       2,
@@ -2245,7 +2238,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
         "allowTaggedTemplates": true,
         "allowTernary": true,
         "enforceForJSX": false,
-        "ignoreDirectives": false,
       },
     ],
     "no-unused-labels": [
@@ -2267,10 +2259,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       {
         "allowNamedExports": false,
         "classes": true,
-        "enums": true,
         "functions": true,
-        "ignoreTypeReferences": true,
-        "typedefs": true,
         "variables": true,
       },
     ],
@@ -2297,9 +2286,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
     ],
     "no-useless-escape": [
       2,
-      {
-        "allowRegexCharacters": [],
-      },
     ],
     "no-useless-rename": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/flat/node/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/node/__snapshots__/snapshot.test.js.snap
@@ -556,7 +556,6 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
       {
         "enforceForClassFields": true,
         "exceptMethods": [],
-        "ignoreOverrideMethods": false,
       },
     ],
     "complexity": [
@@ -625,7 +624,6 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
       "expression",
       {
         "allowArrowFunctions": false,
-        "allowTypeAnnotation": false,
         "overrides": {},
       },
     ],
@@ -1693,16 +1691,11 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
         "allow": [],
         "builtinGlobals": false,
         "hoist": "functions",
-        "ignoreFunctionTypeParameterNameValueShadow": true,
         "ignoreOnInitialization": false,
-        "ignoreTypeValueShadow": true,
       },
     ],
     "no-shadow-restricted-names": [
       2,
-      {
-        "reportGlobalThis": false,
-      },
     ],
     "no-sparse-arrays": [
       2,
@@ -1788,7 +1781,6 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
         "allowTaggedTemplates": true,
         "allowTernary": true,
         "enforceForJSX": false,
-        "ignoreDirectives": false,
       },
     ],
     "no-unused-labels": [
@@ -1810,10 +1802,7 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
       {
         "allowNamedExports": false,
         "classes": true,
-        "enums": true,
         "functions": true,
-        "ignoreTypeReferences": true,
-        "typedefs": true,
         "variables": true,
       },
     ],
@@ -1840,9 +1829,6 @@ exports[`should match ESLint Flat Configuration snapshot: node 1`] = `
     ],
     "no-useless-escape": [
       2,
-      {
-        "allowRegexCharacters": [],
-      },
     ],
     "no-useless-rename": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/react/__snapshots__/snapshot.test.js.snap
@@ -178,7 +178,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,
@@ -497,7 +497,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       {
         "enforceForClassFields": true,
         "exceptMethods": [],
-        "ignoreOverrideMethods": false,
       },
     ],
     "complexity": [
@@ -566,7 +565,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       "expression",
       {
         "allowArrowFunctions": false,
-        "allowTypeAnnotation": false,
         "overrides": {},
       },
     ],
@@ -2087,16 +2085,11 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
         "allow": [],
         "builtinGlobals": false,
         "hoist": "functions",
-        "ignoreFunctionTypeParameterNameValueShadow": true,
         "ignoreOnInitialization": false,
-        "ignoreTypeValueShadow": true,
       },
     ],
     "no-shadow-restricted-names": [
       2,
-      {
-        "reportGlobalThis": false,
-      },
     ],
     "no-sparse-arrays": [
       2,
@@ -2182,7 +2175,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
         "allowTaggedTemplates": true,
         "allowTernary": true,
         "enforceForJSX": false,
-        "ignoreDirectives": false,
       },
     ],
     "no-unused-labels": [
@@ -2204,10 +2196,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
       {
         "allowNamedExports": false,
         "classes": true,
-        "enums": true,
         "functions": true,
-        "ignoreTypeReferences": true,
-        "typedefs": true,
         "variables": true,
       },
     ],
@@ -2234,9 +2223,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Configuration s
     ],
     "no-useless-escape": [
       2,
-      {
-        "allowRegexCharacters": [],
-      },
     ],
     "no-useless-rename": [
       2,

--- a/packages/eslint-config/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
+++ b/packages/eslint-config/tests/snapshot-test/flat/storybook/__snapshots__/snapshot.test.js.snap
@@ -178,7 +178,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       2,
     ],
     "@typescript-eslint/no-deprecated": [
-      2,
+      1,
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       2,
@@ -497,7 +497,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       {
         "enforceForClassFields": true,
         "exceptMethods": [],
-        "ignoreOverrideMethods": false,
       },
     ],
     "complexity": [
@@ -566,7 +565,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       "expression",
       {
         "allowArrowFunctions": false,
-        "allowTypeAnnotation": false,
         "overrides": {},
       },
     ],
@@ -1844,16 +1842,11 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
         "allow": [],
         "builtinGlobals": false,
         "hoist": "functions",
-        "ignoreFunctionTypeParameterNameValueShadow": true,
         "ignoreOnInitialization": false,
-        "ignoreTypeValueShadow": true,
       },
     ],
     "no-shadow-restricted-names": [
       2,
-      {
-        "reportGlobalThis": false,
-      },
     ],
     "no-sparse-arrays": [
       2,
@@ -1939,7 +1932,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
         "allowTaggedTemplates": true,
         "allowTernary": true,
         "enforceForJSX": false,
-        "ignoreDirectives": false,
       },
     ],
     "no-unused-labels": [
@@ -1961,10 +1953,7 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
       {
         "allowNamedExports": false,
         "classes": true,
-        "enums": true,
         "functions": true,
-        "ignoreTypeReferences": true,
-        "typedefs": true,
         "variables": true,
       },
     ],
@@ -1991,9 +1980,6 @@ exports[`ESLint Configuration Snapshot Tests should match ESLint Flat Configurat
     ],
     "no-useless-escape": [
       2,
-      {
-        "allowRegexCharacters": [],
-      },
     ],
     "no-useless-rename": [
       2,


### PR DESCRIPTION
## What changed / motivation ?

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please include relevant motivation and context. -->

- Added the `@typescript-eslint/no-deprecated` rule to allow the use of the `@deprecated` tag in JSDoc.
  - This change is intended to permit the use of the `@deprecated` tag during the code migration phase.
  - Details: [no-deprecated | typescript-eslint](https://typescript-eslint.io/rules/no-deprecated/)
- Updated snapshot tests to reflect the rule changes.

## Linked PR / Issues

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [ ] Performed a self-review of my code

## References

<!-- List all links to information referenced in creating this PR. -->

- [no-deprecated | typescript-eslint](https://typescript-eslint.io/rules/no-deprecated/)