### PR TITLE
ci: add OIDC configuration to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   release:


### PR DESCRIPTION
## What changed / motivation ?

Added OIDC configuration to the release workflow by including `id-token: write` permission. This enables npm provenance for enhanced supply-chain security as recommended by semantic-release documentation, addressing the Nx incident mentioned in https://blog.jxck.io/entries/2025-09-03/nx-incidents.html.

## Linked PR / Issues

Addresses security concerns from the Nx incident regarding npm package security.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Chore (routine task, maintenance, or non-functional change that doesn't modify src or test files)

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines](https://github.com/moneyforward/frontend-tools/blob/main/.github/CONTRIBUTING.md)
- [x] Performed a self-review of my code

## References

- [semantic-release GitHub Actions configuration](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions)
- [Nx incident blog post](https://blog.jxck.io/entries/2025-09-03/nx-incidents.html)

🤖 Generated with [Claude Code](https://claude.ai/code)