### PR TITLE
chore: fix CODEOWNERS header, restrict changes to Head of Development, delegate mf-tsd-admin review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,5 +30,7 @@
 # - You can ask your "Quality Controller" to review and approve your work by writing `* @moneyforward/hoge_reviewers`.
 # - To add or remove "Quality Controller", please ask "Head of Development".
 # - "Head of Development" is the github team maintainer of "Quality Controller".
-
-* @moneyforward/mf-tsd-admin @moneyforward/mf-web-frontend-committee-admin @moneyforward/mf-frontend-forward-admin
+#
+# - @moneyforward/mf-tsd-admin delegates its review authority to the path-specific reviewer teams below,
+#   and is excluded from automatic review request assignment.
+* @moneyforward/mf-web-frontend-committee-admin @moneyforward/mf-frontend-forward-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 # - If you want to change "Head of Development", please create a pull request rewriting "Head of Development" line in this file and merge it after getting approval from "Person Responsible for Overseeing Development".
 # - Please also make changes the github team maintainer of "Quality Controller" for this product at the same time.
 # - "Head of Development" should join the Slack channel where notifications about the creation of pull requests for this repository will appear.
-/.github/CODEOWNERS @wata-gh
+/.github/CODEOWNERS @wata-gh @chrismcmf
 #
 # Quality Controller (品質管理担当者)
 # @moneyforward/mf-tsd-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,10 @@
 # - If you want to change "Head of Development", please create a pull request rewriting "Head of Development" line in this file and merge it after getting approval from "Person Responsible for Overseeing Development".
 # - Please also make changes the github team maintainer of "Quality Controller" for this product at the same time.
 # - "Head of Development" should join the Slack channel where notifications about the creation of pull requests for this repository will appear.
+/.github/CODEOWNERS @wata-gh
 #
 # Quality Controller (品質管理担当者)
-* @moneyforward/oss-frontend 
+# @moneyforward/mf-tsd-admin
 #
 # - For various audit compliance purposes, "Quality Controller" is managed on GitHub Team.
 # - A GitHub Team just for the purpose of managing "Quality Controller", separate from the regular developer team.


### PR DESCRIPTION
## Summary
- Fix the CODEOWNERS "Quality Controller" comment header, which had been overwritten by a real (but dead — always superseded by the wildcard rule below it) `* @moneyforward/oss-frontend` rule.
- Restrict changes to `.github/CODEOWNERS` itself to the Head of Development (`@wata-gh`) and `@chrismcmf`, since this file governs who is authorized to review/approve.
- `mf-tsd-admin` remains the documented Quality Controller for audit purposes, but delegates day-to-day review to the path-specific reviewer teams already configured in this file (`mf-web-frontend-committee-admin`, `mf-frontend-forward-admin`), and is excluded from automatic review request assignment. As repo admin it can still bypass CI / merge directly when genuinely needed.